### PR TITLE
Fix duplicate license badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Utonoma
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![License: MIT](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/license/apache-2-0)
 
 Utonoma is a social network like no other. It works on the blockchain and allows content creators to earn cryptocurrencies for each like. Only one condition: if a content has too many dislikes it will be removed from the platform. This small change in the rules allows content moderation in a democratic and decentralized way, contributing to the creation of the freer internet we all dream of.
 


### PR DESCRIPTION
Removed duplicate MIT license badge from README.